### PR TITLE
fixed capitalization of 'Deploying Snowclone to Your Cloud'

### DIFF
--- a/casestudy/cloud-deployment/index.html
+++ b/casestudy/cloud-deployment/index.html
@@ -222,7 +222,7 @@
                   <nav id=TableOfContents>
                     <ul>
                       <li>
-                        <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to your Cloud</a>
+                        <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to Your Cloud</a>
                       </li>
                       <li>
                         <a href=#compute>Compute</a>
@@ -259,7 +259,7 @@
             <nav id=TableOfContents>
               <ul>
                 <li>
-                  <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to your Cloud</a>
+                  <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to Your Cloud</a>
                 </li>
                 <li>
                   <a href=#compute>Compute</a>
@@ -290,7 +290,7 @@
           </div>
         </nav>
         <main class="docs-content col-lg-12 col-xl-10">
-          <h1 id=deploying-snowclone-to-your-cloud>Deploying Snowclone to your Cloud
+          <h1 id=deploying-snowclone-to-your-cloud>Deploying Snowclone to Your Cloud
             <a href=#deploying-snowclone-to-your-cloud class=anchor aria-hidden=true>#</a>
           </h1>
           <p>The goal for deploying Snowclone to a user’s cloud was simple: to provide the full Snowclone stack, but
@@ -337,7 +337,7 @@
                     <nav id=TableOfContents>
                       <ul>
                         <li>
-                          <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to your Cloud</a>
+                          <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to Your Cloud</a>
                         </li>
                         <li>
                           <a href=#compute>Compute</a>
@@ -374,7 +374,7 @@
               <nav id=TableOfContents>
                 <ul>
                   <li>
-                    <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to your Cloud</a>
+                    <a href=#deploying-snowclone-to-your-cloud>Deploying Snowclone to Your Cloud</a>
                   </li>
                   <li>
                     <a href=#compute>Compute</a>


### PR DESCRIPTION
- appeared previously as "Deploying Snowclone to your Cloud" 
- might need to fix listings in table of contents elsewhere in site